### PR TITLE
Fix README anchor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 <p></p>
 <div align="center">
   <a href="https://github.com/Ser-AM">
-  
-</div>
-<div align="center">
     <img height="180em" src="https://github-readme-stats-git-masterrstaa-rickstaa.vercel.app/api/top-langs?username=Ser-AM&title_color=ff34234&layout=compact&langs_count=8&theme=dracula"/>
+  </a>
 </div>
 
 <div align="center" style="display: inline_block"><br>


### PR DESCRIPTION
## Summary
- fix unclosed anchor tag around GitHub stats image

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684184a2c1c8832cbd7bb07f5d58d45d